### PR TITLE
Feature: Scan Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ test-output/
 
 # Generated reports
 archctl-report.html
+
+# Architecture Control Cache
+.archctl/cache.json

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -89,6 +89,22 @@ export async function cmdInit(args: ParsedArgs): Promise<void> {
   // Write config file
   configService.saveConfig(configPath, config);
 
+  // Write .gitignore for cache
+  try {
+    const gitignorePath = path.join(outDir, '.gitignore');
+    if (!fs.existsSync(gitignorePath)) {
+      fs.writeFileSync(gitignorePath, 'cache.json\n', 'utf-8');
+    } else {
+      // Append if exists and not already ignored
+      const content = fs.readFileSync(gitignorePath, 'utf-8');
+      if (!content.includes('cache.json')) {
+        fs.appendFileSync(gitignorePath, '\ncache.json\n', 'utf-8');
+      }
+    }
+  } catch (error) {
+    // Ignore error
+  }
+
   // Copy AI setup guide
   const aiGuideSourcePath = path.join(
     __dirname,

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -18,12 +18,14 @@ export async function cmdLint(_args: ParsedArgs): Promise<void> {
   const isJsonOutput = format === 'json';
   const isHtmlOutput = format === 'html';
   const outputFile = _args.output as string | undefined;
+  const noCache = (_args['no-cache'] as boolean) || false;
 
   // Debug: log the format flag
   if (process.env.DEBUG_ARCHCTL) {
     console.error('DEBUG: _args =', JSON.stringify(_args));
     console.error('DEBUG: format =', format);
     console.error('DEBUG: isJsonOutput =', isJsonOutput);
+    console.error('DEBUG: noCache =', noCache);
   }
 
   try {
@@ -55,6 +57,7 @@ export async function cmdLint(_args: ParsedArgs): Promise<void> {
   const result = await graphService.analyzeProjectGraph({
     projectRoot,
     config,
+    useCache: !noCache,
   });
 
   const graphAnalysis = graphService.generateGraphReport(result.graph, result.stats, config.name);

--- a/src/infrastructure/cache/cacheService.ts
+++ b/src/infrastructure/cache/cacheService.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import type { ScanResult } from '../../types/scanner';
+
+export interface CacheEntry {
+  hash: string;
+  result: ScanResult;
+  timestamp: number;
+}
+
+export interface CacheStore {
+  version: string;
+  entries: Record<string, CacheEntry>;
+}
+
+export class CacheService {
+  private cachePath: string;
+  private store: CacheStore;
+  private isDirty: boolean = false;
+  private readonly CACHE_VERSION = '1.0.0';
+
+  constructor(projectRoot: string) {
+    this.cachePath = path.join(projectRoot, '.archctl', 'cache.json');
+    this.store = this.loadStore();
+  }
+
+  private loadStore(): CacheStore {
+    try {
+      if (fs.existsSync(this.cachePath)) {
+        const content = fs.readFileSync(this.cachePath, 'utf-8');
+        const data = JSON.parse(content) as CacheStore;
+        if (data.version === this.CACHE_VERSION) {
+          return data;
+        }
+      }
+    } catch (error) {
+      // Ignore errors, start with empty cache
+    }
+    return { version: this.CACHE_VERSION, entries: {} };
+  }
+
+  public get(filePath: string, contentHash: string): ScanResult | null {
+    const entry = this.store.entries[filePath];
+    if (entry && entry.hash === contentHash) {
+      return entry.result;
+    }
+    return null;
+  }
+
+  public set(filePath: string, contentHash: string, result: ScanResult): void {
+    this.store.entries[filePath] = {
+      hash: contentHash,
+      result,
+      timestamp: Date.now(),
+    };
+    this.isDirty = true;
+  }
+
+  public save(): void {
+    if (!this.isDirty) return;
+
+    try {
+      const dir = path.dirname(this.cachePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(this.cachePath, JSON.stringify(this.store, null, 2), 'utf-8');
+      this.isDirty = false;
+    } catch (error) {
+      console.warn('Failed to save cache:', error);
+    }
+  }
+
+  public clear(): void {
+    this.store = { version: this.CACHE_VERSION, entries: {} };
+    this.isDirty = true;
+    this.save();
+  }
+
+  public static computeHash(content: string, extraContext: string = ''): string {
+    return crypto.createHash('md5').update(content).update(extraContext).digest('hex');
+  }
+}

--- a/src/services/graphService.ts
+++ b/src/services/graphService.ts
@@ -17,6 +17,7 @@ import { parseGitignore, mergeExcludes } from '../utils/gitignore';
 export interface GraphAnalysisInput {
   projectRoot: string;
   config: ArchctlConfig;
+  useCache?: boolean;
 }
 
 export interface GraphAnalysisResult {
@@ -125,7 +126,7 @@ export function scanProjectFiles(
  * Analyze project dependencies and generate graph
  */
 export async function analyzeProjectGraph(input: GraphAnalysisInput): Promise<GraphAnalysisResult> {
-  const { projectRoot, config } = input;
+  const { projectRoot, config, useCache = true } = input;
 
   // Get excludes
   const { allExcludes, gitignoreCount, configCount } = getProjectExcludes(projectRoot, config);
@@ -138,6 +139,7 @@ export async function analyzeProjectGraph(input: GraphAnalysisInput): Promise<Gr
     projectRoot,
     files,
     config,
+    useCache,
   });
 
   const stats = getGraphStats(graph);

--- a/vscode-extension/.archctl/cache.json
+++ b/vscode-extension/.archctl/cache.json
@@ -1,0 +1,198 @@
+{
+  "version": "1.0.0",
+  "entries": {
+    "src/application/check-service.ts": {
+      "hash": "410a878913586b9e12a2ab4a3388ab07",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/application/check-service.ts",
+            "path": "src/application/check-service.ts",
+            "language": "typescript",
+            "layer": "application",
+            "imports": [
+              "path"
+            ]
+          }
+        ],
+        "edges": [
+          {
+            "from": "src/application/check-service.ts",
+            "to": "src/domain/types.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          },
+          {
+            "from": "src/application/check-service.ts",
+            "to": "src/infrastructure/file-scanner.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          },
+          {
+            "from": "src/application/check-service.ts",
+            "to": "src/infrastructure/archctl-executor.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          }
+        ]
+      },
+      "timestamp": 1765485770341
+    },
+    "src/domain/types.ts": {
+      "hash": "19cafb61a014bc126dc078835ba4defd",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/domain/types.ts",
+            "path": "src/domain/types.ts",
+            "language": "typescript",
+            "layer": "domain"
+          }
+        ],
+        "edges": []
+      },
+      "timestamp": 1765485770342
+    },
+    "src/extension.ts": {
+      "hash": "35e24e21d35d6df3fc9a43c7609dad15",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/extension.ts",
+            "path": "src/extension.ts",
+            "language": "typescript",
+            "layer": "presentation",
+            "imports": [
+              "vscode"
+            ]
+          }
+        ],
+        "edges": [
+          {
+            "from": "src/extension.ts",
+            "to": "src/application/check-service.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          },
+          {
+            "from": "src/extension.ts",
+            "to": "src/presentation/diagnostic-mapper.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          },
+          {
+            "from": "src/extension.ts",
+            "to": "src/shared/config-helper.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          },
+          {
+            "from": "src/extension.ts",
+            "to": "src/domain/types.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          }
+        ]
+      },
+      "timestamp": 1765485770349
+    },
+    "src/infrastructure/archctl-executor.ts": {
+      "hash": "9de484d66bede71298c7e5a2f41afe0e",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/infrastructure/archctl-executor.ts",
+            "path": "src/infrastructure/archctl-executor.ts",
+            "language": "typescript",
+            "layer": "infrastructure",
+            "imports": [
+              "child_process",
+              "util",
+              "path"
+            ]
+          }
+        ],
+        "edges": [
+          {
+            "from": "src/infrastructure/archctl-executor.ts",
+            "to": "src/domain/types.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          }
+        ]
+      },
+      "timestamp": 1765485770354
+    },
+    "src/infrastructure/file-scanner.ts": {
+      "hash": "a48793f2077189d06246e774c2070d70",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/infrastructure/file-scanner.ts",
+            "path": "src/infrastructure/file-scanner.ts",
+            "language": "typescript",
+            "layer": "infrastructure",
+            "imports": [
+              "path",
+              "fs"
+            ]
+          }
+        ],
+        "edges": []
+      },
+      "timestamp": 1765485770355
+    },
+    "src/presentation/diagnostic-mapper.ts": {
+      "hash": "44966e76d1273298af4721d4946194f2",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/presentation/diagnostic-mapper.ts",
+            "path": "src/presentation/diagnostic-mapper.ts",
+            "language": "typescript",
+            "layer": "presentation",
+            "imports": [
+              "vscode"
+            ]
+          }
+        ],
+        "edges": [
+          {
+            "from": "src/presentation/diagnostic-mapper.ts",
+            "to": "src/domain/types.ts",
+            "kind": "import",
+            "confidence": 0.99,
+            "source": "ts-js-import"
+          }
+        ]
+      },
+      "timestamp": 1765485770358
+    },
+    "src/shared/config-helper.ts": {
+      "hash": "f4d158f07400a1cbd6f48ecd74fdc056",
+      "result": {
+        "nodes": [
+          {
+            "id": "src/shared/config-helper.ts",
+            "path": "src/shared/config-helper.ts",
+            "language": "typescript",
+            "layer": "shared",
+            "imports": [
+              "vscode"
+            ]
+          }
+        ],
+        "edges": []
+      },
+      "timestamp": 1765485770359
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR implements a caching mechanism for `archctl lint` to significantly improve performance on repeated runs, especially for large codebases.

Closes #15

## Changes

### Performance
- **Caching (`.archctl/cache.json`)**: Stores the results of file scans (AST parsing, dependency extraction).
- **Cache Invalidation**: Automatically invalidates cache entries if:
  - The file content changes (detected via MD5 hash).
  - The project configuration (rules, layers, capabilities) changes.
  - The `tsconfig.json` changes.

### CLI Updates
- **`--no-cache` Flag**: Added to `archctl lint` to force a fresh scan and clear the existing cache.
- **`init` Command**: Now automatically creates a `.gitignore` inside the `.archctl` directory to ensure `cache.json` is not committed.

### Technical Details
- **`CacheService`**: Handles storage and retrieval of scan results.
- **`GraphBuilder` Integration**: Modified `buildProjectGraph` to check the cache before triggering expensive scanners.

## verification
1. Run `archctl lint`. The first run will create `.archctl/cache.json`.
2. Run `archctl lint` again. It should be faster (verifiable on large projects) and produce the same output.
3. Run `archctl lint --no-cache`. This will ignore/clear the cache and perform a full scan.